### PR TITLE
fix(frontend): Make CEO agent card clickable

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -1,0 +1,3 @@
+
+> my-app@0.1.0 dev
+> PORT=8000 next dev --turbopack

--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -329,7 +329,11 @@ export default function AgentPanel({ onAgentMessage }: AgentPanelProps) {
       </div>
       
       {/* CEO Card with LLM Settings */}
-      <div className="bg-gray-700 p-4 rounded-md flex items-center space-x-3 mb-4 border-2 border-yellow-400 relative overflow-hidden">
+      <div
+        className="bg-gray-700 p-4 rounded-md flex items-center space-x-3 mb-4 border-2 border-yellow-400 relative overflow-hidden"
+        style={{ cursor: 'pointer' }}
+        onClick={(e) => handleOpenLLMSettings(e, "CEO")}
+      >
         <div className="absolute inset-0 bg-yellow-400/5"></div>
         <div className="relative">
           <img


### PR DESCRIPTION
The CEO agent card was not opening the settings dialog when clicked. This was because the main div for the card was missing an onClick handler.

This change adds an onClick handler to the CEO agent card's main div, making the entire card clickable. This improves the user experience as the user can now click anywhere on the card to open the settings.

A cursor: 'pointer' style was also added to provide a visual cue that the card is clickable.