### PR TITLE
feat(llm): Refactor LLM integration to support Chat Completions API

### DIFF
--- a/src/components/LLMSettingsDialog.tsx
+++ b/src/components/LLMSettingsDialog.tsx
@@ -152,6 +152,17 @@ export default function LLMSettingsDialog({
                   placeholder="Enter your API key"
                 />
               </div>
+              <div className="grid gap-2">
+                <Label htmlFor="model">Model</Label>
+                <Input
+                  id="model"
+                  value={config.model}
+                  onChange={(e) =>
+                    setConfig({ ...config, model: e.target.value })
+                  }
+                  placeholder="e.g. openai/gpt-4o"
+                />
+              </div>
             </>
           )}
 

--- a/src/models/LLMConfig.ts
+++ b/src/models/LLMConfig.ts
@@ -6,16 +6,18 @@ export interface LLMConfig {
   promptInjection: string;
   temperature?: number;
   maxTokens?: number;
+  model?: string;
 }
 
 export const defaultLLMConfig: LLMConfig = {
   mode: "local",
   localEndpoint: "http://localhost:5000/api/llm",
-  commercialEndpoint: "https://api.openai.com/v1/completions",
+  commercialEndpoint: "https://openrouter.ai/api/v1/chat/completions",
   apiKey: "",
   promptInjection: "",
   temperature: 0.7,
-  maxTokens: 2048
+  maxTokens: 2048,
+  model: "openai/gpt-4o"
 };
 
 export type LLMResponse = {


### PR DESCRIPTION
This commit refactors the LLM integration to use the OpenAI Chat Completions API format, which is the standard for services like OpenRouter, Requesty, and LiteLLM.

The `queryCommercialLLM` function has been updated to send a `messages` array instead of a `prompt` string. The `LLMConfig` model has been updated to include a `model` property, and the settings dialog has been updated to allow users to configure the model.

The `queryLocalLLM` function has also been updated to accept a `messages` array for a consistent internal API.